### PR TITLE
Fix bug when setting top class for jsonschema generator

### DIFF
--- a/linkml_validator/utils.py
+++ b/linkml_validator/utils.py
@@ -68,7 +68,7 @@ def get_jsonschema(schema: str, py_target_class: object = None, generator: Gener
         kwargs["not_closed"] = False
     top_class = py_target_class.class_name if py_target_class else None
     generator = get_generator(generator, **kwargs)
-    generator.topCls = top_class
+    generator.top_class = top_class
     jsonschemastr = generator.serialize()
     jsonschema_obj = json.loads(jsonschemastr)
     return jsonschema_obj


### PR DESCRIPTION
Fix bug when setting top class for jsonschema generator. This resolves the behavior seen in #15 


